### PR TITLE
fix(cli): Makes test utils cross platform

### DIFF
--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -22,8 +22,7 @@ base64 = "0.13"
 log = "0.4"
 serde = { version = "1.0", features=["derive"]}
 serde_json = "1.0"
-termion = "1.5"
+termcolor = "1.1"
 tokio = { version = "1", features = ["full"]}
 toml = "0.5"
 wascap = "0.6"
-


### PR DESCRIPTION
This switches to the `termcolor` crate, which provides cross-platform
support for adding terminal colors.

Closes #2