### PR TITLE
don't override log_level if it's not a simple level value

### DIFF
--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-test-util"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/wasmcloud/wasmcloud-test"
 readme = "README.md"
 
 [dependencies]
-wasmcloud-interface-testing = {version = "0.3.1", path="../../interfaces/testing/rust"}
+wasmcloud-interface-testing = "0.3.1"
 wasmbus-rpc = "0.7.5"
 regex = "1"
 

--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/wasmcloud/wasmcloud-test"
 readme = "README.md"
 
 [dependencies]
-wasmcloud-interface-testing = "0.3"
-wasmbus-rpc = "0.7"
+wasmcloud-interface-testing = "0.3.0"
+wasmbus-rpc = "0.7.4"
 regex = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/wasmcloud/wasmcloud-test"
 readme = "README.md"
 
 [dependencies]
-wasmcloud-interface-testing = "0.3.0"
-wasmbus-rpc = "0.7.4"
+wasmcloud-interface-testing = {version = "0.3.1", path="../../interfaces/testing/rust"}
+wasmbus-rpc = "0.7.5"
 regex = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/wasmcloud-test-util/src/provider_test.rs
+++ b/wasmcloud-test-util/src/provider_test.rs
@@ -280,12 +280,11 @@ pub async fn start_provider_test(config: TomlMap) -> Result<Provider, anyhow::Er
     // set logging level for capability provider with the "RUST_LOG" environment variable,
     // default level is "info"
     let log_level = match config.get("rust_log") {
-        Some(TomlValue::String(level)) if level.parse::<log::Level>().is_ok() => level.to_string(),
-        None => "info".to_string(),
-        Some(x) => {
-            eprintln!("invalid 'rust_log' setting '{}', using 'info'", x);
-            "info".to_string()
+        Some(TomlValue::String(level)) => {
+            eprintln!("Setting provider logging level to {}", &level);
+            level.to_string()
         }
+        _ => "info".to_string(),
     };
     // set RUST_BACKTRACE, if requested
     // default is disabled

--- a/wasmcloud-test-util/src/provider_test.rs
+++ b/wasmcloud-test-util/src/provider_test.rs
@@ -12,8 +12,9 @@ use tokio::sync::OnceCell;
 use toml::value::Value as TomlValue;
 use wasmbus_rpc::{
     anats,
+    common::{Context, Message, SendOpts, Transport},
     core::{HealthCheckRequest, HealthCheckResponse, HostData, LinkDefinition, WasmCloudEntity},
-    Context, Message, RpcError, RpcResult, SendOpts, Transport,
+    error::{RpcError, RpcResult},
 };
 
 pub type SimpleValueMap = std::collections::HashMap<String, String>;
@@ -319,6 +320,7 @@ pub async fn start_provider_test(config: TomlMap) -> Result<Provider, anyhow::Er
 
     // provider's stdout is piped through our stdout
     let mut child_proc = std::process::Command::new(&exe_path)
+        .stdout(std::process::Stdio::piped())
         .stdin(std::process::Stdio::piped())
         .env("RUST_LOG", &log_level)
         .env("RUST_BACKTRACE", enable_backtrace)


### PR DESCRIPTION
Package version 0.2.1

**Fix**
- don't overwrite `log_level` (in `provider_test_config.toml`)  if it doesn't parse to a simple level value. (see https://github.com/wasmCloud/weld/pull/80) 

Note: upgrades dependency wasmbus_rpc to 0.7.4. The build check will fail until PR https://github.com/wasmCloud/weld/pull/80 has been merged and the new wasmcloud_rpc is pushed to crates.io

Signed-off-by: stevelr <steve@cosmonic.com>