### PR TITLE
use smithy-bindgen to gen interface, re-export as 'testing'

### DIFF
--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-test-util"
-version = "0.6.5"
+version = "0.7.0"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
@@ -10,21 +10,20 @@ repository = "https://github.com/wasmcloud/wasmcloud-test"
 readme = "README.md"
 
 [dependencies]
-smithy-bindgen = { git="https://github.com/wasmcloud/weld", branch="feat/smithy-bindgen" }
-wasmbus-rpc = { git="https://github.com/wasmcloud/weld", rev="4faec462d1dd41efbfe95c9e2d2061a9a40f2fcc", features = [ "otel" ] }
+smithy-bindgen = "0.1.0"
+wasmbus-rpc = { version = "0.12", features = [ "otel" ] }
 serde_bytes = "0.11"
 regex = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-async-nats = "0.23.0"
 futures = "0.3"
-base64 = "0.13"
+base64 = "0.21"
 log = "0.4"
 nkeys = "0.2.0"
 serde = { version = "1.0", features=["derive"]}
 serde_json = "1.0"
 termcolor = "1.1"
 tokio = { version = "1", features = ["full"]}
-toml = "0.5"
+toml = "0.7"

--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-test-util"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"
@@ -10,8 +10,9 @@ repository = "https://github.com/wasmcloud/wasmcloud-test"
 readme = "README.md"
 
 [dependencies]
-wasmcloud-interface-testing = "0.7.1"
-wasmbus-rpc = "0.11.2"
+smithy-bindgen = { git="https://github.com/wasmcloud/weld", branch="feat/smithy-bindgen" }
+wasmbus-rpc = { git="https://github.com/wasmcloud/weld", rev="4faec462d1dd41efbfe95c9e2d2061a9a40f2fcc", features = [ "otel" ] }
+serde_bytes = "0.11"
 regex = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/wasmcloud-test-util/src/cli.rs
+++ b/wasmcloud-test-util/src/cli.rs
@@ -1,9 +1,9 @@
 //! cli utilities
 use std::io::Write;
 
+use crate::testing::TestResult;
 use serde::Deserialize;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
-use wasmcloud_interface_testing::TestResult;
 
 // structure for deserializing error results
 #[derive(Deserialize)]

--- a/wasmcloud-test-util/src/lib.rs
+++ b/wasmcloud-test-util/src/lib.rs
@@ -29,10 +29,9 @@ pub mod testing {
 
     // convert empty RpcResult into a testResult
     impl<'name, T: Serialize> From<NamedResult<'name, T>> for TestResult {
-        fn from(name_res: NamedResult<'name, T>) -> TestResult {
-            let test_case_name = name_res.0.to_string();
-            let test_case_result = name_res.1;
-            match test_case_result {
+        fn from((name, res): NamedResult<'name, T>) -> TestResult {
+            let name = name.into();
+            match res {
                 Ok(res) => {
                     // test passed. Serialize the data to json
                     let data = match serde_json::to_vec(&res) {
@@ -46,7 +45,7 @@ pub mod testing {
                         Err(_) => b"".to_vec(),
                     };
                     TestResult {
-                        name: test_case_name,
+                        name,
                         passed: true,
                         snap_data: Some(data),
                     }
@@ -60,7 +59,7 @@ pub mod testing {
                     ))
                     .ok();
                     TestResult {
-                        name: test_case_name,
+                        name,
                         passed: false,
                         snap_data: data,
                     }

--- a/wasmcloud-test-util/src/lib.rs
+++ b/wasmcloud-test-util/src/lib.rs
@@ -4,12 +4,64 @@ pub mod provider_test;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod cli;
 
-// re-export testing interface
-pub use wasmcloud_interface_testing as testing;
-
 // re-export regex and nkeys
 pub use nkeys;
 pub use regex;
+
+#[allow(dead_code)]
+pub mod testing {
+
+    smithy_bindgen::smithy_bindgen!("testing/testing.smithy", "org.wasmcloud.interface.testing");
+
+    // after sdk is split we won't have to duplicate this code
+    impl Default for TestOptions {
+        fn default() -> TestOptions {
+            TestOptions {
+                patterns: vec![".*".to_string()],
+                options: std::collections::HashMap::default(),
+            }
+        }
+    }
+
+    pub type NamedResult<'name, T> = (&'name str, RpcResult<T>);
+
+    // convert empty RpcResult into a testResult
+    impl<'name, T: Serialize> From<NamedResult<'name, T>> for TestResult {
+        fn from(name_res: NamedResult<'name, T>) -> TestResult {
+            match name_res.1 {
+                Ok(res) => {
+                    // TODO: if serialization of data fails, it doesn't change
+                    // the test result, but serialization errors should be logged.
+                    // Logging requires us to have logging set up
+                    // (we might be running in an actor)
+                    let data = match serde_json::to_vec(&res) {
+                        Ok(v) => serde_json::to_vec(&serde_json::json!({ "data": v }))
+                            .unwrap_or_default(),
+                        Err(_) => b"".to_vec(),
+                    };
+                    TestResult {
+                        name: name_res.0.to_string(),
+                        passed: true,
+                        snap_data: Some(data),
+                    }
+                }
+                Err(e) => {
+                    let data = serde_json::to_vec(&serde_json::json!(
+                        {
+                           "error": e.to_string(),
+                        }
+                    ))
+                    .ok();
+                    TestResult {
+                        name: name_res.0.to_string(),
+                        passed: false,
+                        snap_data: data,
+                    }
+                }
+            }
+        }
+    }
+}
 
 // these macros are supported on all build targets (wasm32 et. al.)
 

--- a/wasmcloud-test-util/src/lib.rs
+++ b/wasmcloud-test-util/src/lib.rs
@@ -8,7 +8,6 @@ pub mod cli;
 pub use nkeys;
 pub use regex;
 
-#[allow(dead_code)]
 pub mod testing {
 
     smithy_bindgen::smithy_bindgen!("testing/testing.smithy", "org.wasmcloud.interface.testing");

--- a/wasmcloud-test-util/src/lib.rs
+++ b/wasmcloud-test-util/src/lib.rs
@@ -22,29 +22,37 @@ pub mod testing {
         }
     }
 
+    /// A NamedResult, generated inside a `run_selected!`` or `run_selected_spawn!`` macro,
+    /// contains a tuple of a test case name and its result. The implementation of From here
+    /// makes it easy to use the `into()` function to turn the NamedResult into a TestResult.
     pub type NamedResult<'name, T> = (&'name str, RpcResult<T>);
 
     // convert empty RpcResult into a testResult
     impl<'name, T: Serialize> From<NamedResult<'name, T>> for TestResult {
         fn from(name_res: NamedResult<'name, T>) -> TestResult {
-            match name_res.1 {
+            let test_case_name = name_res.0.to_string();
+            let test_case_result = name_res.1;
+            match test_case_result {
                 Ok(res) => {
-                    // TODO: if serialization of data fails, it doesn't change
-                    // the test result, but serialization errors should be logged.
-                    // Logging requires us to have logging set up
-                    // (we might be running in an actor)
+                    // test passed. Serialize the data to json
                     let data = match serde_json::to_vec(&res) {
                         Ok(v) => serde_json::to_vec(&serde_json::json!({ "data": v }))
                             .unwrap_or_default(),
+                        // if serialization of data fails, it doesn't change
+                        // the test result, but serialization errors should be logged.
+                        // Logging requires us to have logging set up, but since we might be running as an actor,
+                        // and we can't force the user to add a logging dependency and set up logging,
+                        // so there isn't much we can do here. Not even println!().
                         Err(_) => b"".to_vec(),
                     };
                     TestResult {
-                        name: name_res.0.to_string(),
+                        name: test_case_name,
                         passed: true,
                         snap_data: Some(data),
                     }
                 }
                 Err(e) => {
+                    // test failed: generate an error message
                     let data = serde_json::to_vec(&serde_json::json!(
                         {
                            "error": e.to_string(),
@@ -52,7 +60,7 @@ pub mod testing {
                     ))
                     .ok();
                     TestResult {
-                        name: name_res.0.to_string(),
+                        name: test_case_name,
                         passed: false,
                         snap_data: data,
                     }

--- a/wasmcloud-test-util/src/provider_test.rs
+++ b/wasmcloud-test-util/src/provider_test.rs
@@ -448,7 +448,7 @@ macro_rules! run_selected_spawn {
                         $tname(&opts).await
                         }
                     ).await;
-                    let tr: testing::TestResult = match join {
+                    let tr: wasmcloud_test_util::testing::TestResult = match join {
                         Ok(res) => (name, res).into(),
                         Err(e) => (name, Err::<(),RpcError>(
                             RpcError::Other(format!("join error: {}", e.to_string()))


### PR DESCRIPTION
# Feature or Problem
- use smithy_bindgen to generate testing interface, re-export as `testing`
- also clarifies namespace of TestResult to avoid ambiguity between internal and external

# Related Issues
Waiting on https://github.com/wasmCloud/weld/pull/143

# Release Information

# Consumer Impact

## Acceptance or Integration

## Manual Verification
Still testing w/ other crates
