### PR TITLE
refactor: remove smithy-bindgen dependency

### DIFF
--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/wasmcloud/wasmcloud-test"
 readme = "README.md"
 
 [dependencies]
-smithy-bindgen = "0.1.0"
 serde_bytes = "0.11"
 regex = "1"
 wasmbus-rpc = { version = "0.14", features = ["otel"]}
+wasmcloud-interface-testing = "0.8.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "1.0"

--- a/wasmcloud-test-util/Cargo.toml
+++ b/wasmcloud-test-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-test-util"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = [ "wasmcloud Team" ]
 license = "Apache-2.0"

--- a/wasmcloud-test-util/src/lib.rs
+++ b/wasmcloud-test-util/src/lib.rs
@@ -8,66 +8,8 @@ pub mod cli;
 pub use nkeys;
 pub use regex;
 
-pub mod testing {
-
-    smithy_bindgen::smithy_bindgen!("testing/testing.smithy", "org.wasmcloud.interface.testing");
-
-    // after sdk is split we won't have to duplicate this code
-    impl Default for TestOptions {
-        fn default() -> TestOptions {
-            TestOptions {
-                patterns: vec![".*".to_string()],
-                options: std::collections::HashMap::default(),
-            }
-        }
-    }
-
-    /// A NamedResult, generated inside a `run_selected!`` or `run_selected_spawn!`` macro,
-    /// contains a tuple of a test case name and its result. The implementation of From here
-    /// makes it easy to use the `into()` function to turn the NamedResult into a TestResult.
-    pub type NamedResult<'name, T> = (&'name str, RpcResult<T>);
-
-    // convert empty RpcResult into a testResult
-    impl<'name, T: Serialize> From<NamedResult<'name, T>> for TestResult {
-        fn from((name, res): NamedResult<'name, T>) -> TestResult {
-            let name = name.into();
-            match res {
-                Ok(res) => {
-                    // test passed. Serialize the data to json
-                    let data = match serde_json::to_vec(&res) {
-                        Ok(v) => serde_json::to_vec(&serde_json::json!({ "data": v }))
-                            .unwrap_or_default(),
-                        // if serialization of data fails, it doesn't change
-                        // the test result, but serialization errors should be logged.
-                        // Logging requires us to have logging set up, but since we might be running as an actor,
-                        // and we can't force the user to add a logging dependency and set up logging,
-                        // so there isn't much we can do here. Not even println!().
-                        Err(_) => b"".to_vec(),
-                    };
-                    TestResult {
-                        name,
-                        passed: true,
-                        snap_data: Some(data),
-                    }
-                }
-                Err(e) => {
-                    // test failed: generate an error message
-                    let data = serde_json::to_vec(&serde_json::json!(
-                        {
-                           "error": e.to_string(),
-                        }
-                    ))
-                    .ok();
-                    TestResult {
-                        name,
-                        passed: false,
-                        snap_data: data,
-                    }
-                }
-            }
-        }
-    }
-}
+// re-export testing interface
+pub use wasmcloud_interface_testing as testing;
 
 // these macros are supported on all build targets (wasm32 et. al.)
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Switch back to using `wasmcloud-interface-testing` instead of `smithy_bindgen`

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
